### PR TITLE
Handle unterminated declaration lists

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -164,13 +164,13 @@ func (parser *Parser) ParseDeclaration() (*css.Declaration, error) {
 	result := css.NewDeclaration()
 	curValue := ""
 
-	for parser.tokenParsable() {
+	for !parser.tokenError() {
 		if parser.tokenChar(":") {
 			result.Property = strings.TrimSpace(curValue)
 			curValue = ""
 
 			parser.shiftToken()
-		} else if parser.tokenChar(";") || parser.tokenChar("}") {
+		} else if parser.tokenChar(";") || parser.tokenChar("}") || parser.tokenEOF() {
 			if result.Property == "" {
 				errMsg := fmt.Sprintf("Unexpected ; character: %s", parser.nextToken().String())
 				return result, errors.New(errMsg)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -601,7 +601,7 @@ func TestAtRuleSupports(t *testing.T) {
 }
 
 func TestParseDeclarations(t *testing.T) {
-	input := `color: blue; text-decoration:underline;`
+	input := `color: blue; text-decoration:underline`
 
 	declarations, err := ParseDeclarations(input)
 	if err != nil {


### PR DESCRIPTION
**what**

Make a small tweak to the CSS parser to handle declaration lists that
are not terminated with a ';' nor a '}'

**why**

We're using douceur to tokenize the css in the `style` attribute of an
html dom node, and in this case it's valid and common to exclude the
trailing semicolon